### PR TITLE
feat: add mcp() hook with tmux-mcp

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,7 +17,9 @@
 
 ## Summary
 
-TODO: Add a short summary of this module.
+p6df module for tmux: terminal multiplexer (`tmux`, `screen` via brew),
+tmux-config plugin, and MCP server (`tmux-mcp` via npm) for
+AI-driven session and pane management.
 
 ## Contributing
 
@@ -39,8 +41,9 @@ TODO: Add a short summary of this module.
 - `p6df::modules::tmux::external::brew()`
 - `p6df::modules::tmux::init(_module, dir)`
   - Args:
-    - _module - 
-    - dir - 
+    - _module
+    - dir
+- `p6df::modules::tmux::mcp()`
 
 #### p6df-tmux/lib
 
@@ -48,21 +51,21 @@ TODO: Add a short summary of this module.
 
 - `p6df::modules::tmux::cmd(...)`
   - Args:
-    - ... - 
+    - ...
 
 ##### p6df-tmux/lib/session.sh
 
 - `p6df::modules::tmux::session::attach(session)`
   - Args:
-    - session - 
+    - session
 - `p6df::modules::tmux::session::make(session, cmd)`
   - Args:
-    - session - 
-    - cmd - 
+    - session
+    - cmd
 - `p6df::modules::tmux::session::new(session, cmd)`
   - Args:
-    - session - 
-    - cmd - 
+    - session
+    - cmd
 
 ## Hierarchy
 

--- a/init.zsh
+++ b/init.zsh
@@ -47,3 +47,17 @@ p6df::modules::tmux::init() {
 
   p6_return_void
 }
+
+######################################################################
+#<
+#
+# Function: p6df::modules::tmux::mcp()
+#
+#>
+######################################################################
+p6df::modules::tmux::mcp() {
+
+  p6_js_npm_global_install "tmux-mcp"
+
+  p6_return_void
+}


### PR DESCRIPTION
## Summary
- Adds `p6df::modules::tmux::mcp()` installing `tmux-mcp` via npm
- Regenerated README with updated function list and Summary

## Test plan
- [ ] `p6df::modules::tmux::mcp()` installs `tmux-mcp`

🤖 Generated with [Claude Code](https://claude.com/claude-code)