### PR TITLE
fix: rename external::brew() -> external::brews() to match framework dispatch

### DIFF
--- a/init.zsh
+++ b/init.zsh
@@ -17,11 +17,11 @@ p6df::modules::tmux::deps() {
 ######################################################################
 #<
 #
-# Function: p6df::modules::tmux::external::brew()
+# Function: p6df::modules::tmux::external::brews()
 #
 #>
 ######################################################################
-p6df::modules::tmux::external::brew() {
+p6df::modules::tmux::external::brews() {
 
   p6df::core::homebrew::cli::brew::install screen
   p6df::core::homebrew::cli::brew::install tmux


### PR DESCRIPTION
## Summary
- Rename `external::brew()` → `external::brews()` to match the plural form dispatched by `p6df-core/lib/module.zsh`

## Test plan
- [ ] Verify `p6df::core::module::brews` dispatch resolves correctly