### PR TITLE
fix(tmux): use single-quoted variables in profile::mod (deferred eval)

### DIFF
--- a/init.zsh
+++ b/init.zsh
@@ -74,6 +74,6 @@ p6df::modules::tmux::mcp() {
 ######################################################################
 p6df::modules::tmux::prompt::system() {
 
-  p6_return_words 'tmux' "$TMUX"
+  p6_return_words 'tmux' '$TMUX'
 }
 


### PR DESCRIPTION
**What:** Restore single-quoted variables in profile::mod p6_return_words calls

**Why:** Variables are intentionally single-quoted; eval happens later via p6_return_words machinery. The SC2016 fix incorrectly expanded them at call time.

**Test plan:** Build CI passes

**Dependencies:** None