### PR TITLE
chore(init): reorder hooks per hook_api.md lifecycle order

### DIFF
--- a/init.zsh
+++ b/init.zsh
@@ -1,11 +1,5 @@
 # shellcheck shell=bash
 ######################################################################
-#<
-#
-# Function: p6df::modules::tmux::deps()
-#
-#>
-######################################################################
 p6df::modules::tmux::deps() {
   ModuleDeps=(
     p6m7g8-dotfiles/p6common
@@ -15,11 +9,13 @@ p6df::modules::tmux::deps() {
 }
 
 ######################################################################
-#<
-#
-# Function: p6df::modules::tmux::external::brews()
-#
-#>
+p6df::modules::tmux::home::symlinks() {
+
+  p6_file_symlink "$P6_DFZ_SRC_P6M7G8_DOTFILES_DIR/p6df-tmux/share/.tmux.conf" "$HOME/.tmux.conf"
+
+  p6_return_void
+}
+
 ######################################################################
 p6df::modules::tmux::external::brews() {
 
@@ -29,27 +25,6 @@ p6df::modules::tmux::external::brews() {
   p6_return_void
 }
 
-######################################################################
-#<
-#
-# Function: p6df::modules::tmux::home::symlinks()
-#
-#  Environment:	 HOME P6_DFZ_SRC_P6M7G8_DOTFILES_DIR
-#>
-######################################################################
-p6df::modules::tmux::home::symlinks() {
-
-  p6_file_symlink "$P6_DFZ_SRC_P6M7G8_DOTFILES_DIR/p6df-tmux/share/.tmux.conf" "$HOME/.tmux.conf"
-
-  p6_return_void
-}
-
-######################################################################
-#<
-#
-# Function: p6df::modules::tmux::mcp()
-#
-#>
 ######################################################################
 p6df::modules::tmux::mcp() {
 
@@ -61,6 +36,31 @@ p6df::modules::tmux::mcp() {
   p6_return_void
 }
 
+######################################################################
+#<
+#
+# Function: p6df::modules::tmux::deps()
+#
+#>
+######################################################################
+#<
+#
+# Function: p6df::modules::tmux::external::brews()
+#
+#>
+######################################################################
+#<
+#
+# Function: p6df::modules::tmux::home::symlinks()
+#
+#  Environment:	 HOME P6_DFZ_SRC_P6M7G8_DOTFILES_DIR
+#>
+######################################################################
+#<
+#
+# Function: p6df::modules::tmux::mcp()
+#
+#>
 ######################################################################
 #<
 #

--- a/init.zsh
+++ b/init.zsh
@@ -1,5 +1,11 @@
 # shellcheck shell=bash
 ######################################################################
+#<
+#
+# Function: p6df::modules::tmux::deps()
+#
+#>
+######################################################################
 p6df::modules::tmux::deps() {
   ModuleDeps=(
     p6m7g8-dotfiles/p6common
@@ -9,6 +15,13 @@ p6df::modules::tmux::deps() {
 }
 
 ######################################################################
+#<
+#
+# Function: p6df::modules::tmux::home::symlinks()
+#
+#  Environment:	 HOME P6_DFZ_SRC_P6M7G8_DOTFILES_DIR
+#>
+######################################################################
 p6df::modules::tmux::home::symlinks() {
 
   p6_file_symlink "$P6_DFZ_SRC_P6M7G8_DOTFILES_DIR/p6df-tmux/share/.tmux.conf" "$HOME/.tmux.conf"
@@ -16,6 +29,12 @@ p6df::modules::tmux::home::symlinks() {
   p6_return_void
 }
 
+######################################################################
+#<
+#
+# Function: p6df::modules::tmux::external::brews()
+#
+#>
 ######################################################################
 p6df::modules::tmux::external::brews() {
 
@@ -25,6 +44,12 @@ p6df::modules::tmux::external::brews() {
   p6_return_void
 }
 
+######################################################################
+#<
+#
+# Function: p6df::modules::tmux::mcp()
+#
+#>
 ######################################################################
 p6df::modules::tmux::mcp() {
 
@@ -36,31 +61,6 @@ p6df::modules::tmux::mcp() {
   p6_return_void
 }
 
-######################################################################
-#<
-#
-# Function: p6df::modules::tmux::deps()
-#
-#>
-######################################################################
-#<
-#
-# Function: p6df::modules::tmux::external::brews()
-#
-#>
-######################################################################
-#<
-#
-# Function: p6df::modules::tmux::home::symlinks()
-#
-#  Environment:	 HOME P6_DFZ_SRC_P6M7G8_DOTFILES_DIR
-#>
-######################################################################
-#<
-#
-# Function: p6df::modules::tmux::mcp()
-#
-#>
 ######################################################################
 #<
 #


### PR DESCRIPTION
## What
Reorder hook functions in `init.zsh` to match the canonical lifecycle order defined in `p6df-core/doc/hook_api.md`.

**Lifecycle:** `deps → init → env::init → path::init → cdpath::init → fpath::init → completions::init → aliases::init → langmgr::init → prompt::init`

**Install-time:** `home::symlinks → external::brews → langs → mcp → vscodes → vscodes::config`

**Profile:** `profile::on → profile::off → profile::mod → prompt::mod::bottom`

## Why
Hook functions were defined in inconsistent order across modules. Enforcing the canonical order makes the files easier to audit and ensures the documented execution sequence is visually obvious.

## Test plan
- [ ] Verified hook order with automated check (all pass)
- [ ] No functional changes — only block reordering

## Dependencies
None